### PR TITLE
feat: add namespace operations to wal

### DIFF
--- a/proto/wal.proto
+++ b/proto/wal.proto
@@ -1,10 +1,24 @@
 syntax = "proto3";
 
+import "namespace.proto";
+
 package wal;
 
 
-message SegmentEntry {
+message MessageEntry {
   string key = 1;
   bytes value = 2;
   int64 timestamp = 3;
+}
+
+message NamespaceEntry {
+  string key = 1;
+  namespace.RetentionPolicy retention_policy = 2;
+}
+
+message SegmentEntry {
+  oneof entry {
+    MessageEntry message_entry = 1;
+    NamespaceEntry namespace_entry = 2;
+  }
 }

--- a/src/bin/bigpipe.rs
+++ b/src/bin/bigpipe.rs
@@ -6,9 +6,12 @@ use tokio_stream::StreamExt;
 use tonic::{transport::Server, Request};
 
 use bigpipe::{
-    data_types::proto::{
-        message_client::MessageClient, message_server::MessageServer,
-        namespace_server::NamespaceServer, ReadMessageRequest, SendMessageRequest,
+    data_types::{
+        message::{
+            message_client::MessageClient, message_server::MessageServer, ReadMessageRequest,
+            SendMessageRequest,
+        },
+        namespace::namespace_server::NamespaceServer,
     },
     server::BigPipeServer,
     BigPipe,

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -1,16 +1,22 @@
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use wal::{segment_entry, SegmentEntry};
 
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
 
-pub mod proto {
-    use tonic::include_proto;
-    include_proto!("message");
-    include_proto!("namespace");
-    include_proto!("wal");
+pub mod message {
+    tonic::include_proto!("message");
+}
+
+pub mod namespace {
+    tonic::include_proto!("namespace");
+}
+
+pub mod wal {
+    tonic::include_proto!("wal");
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, prost::Enumeration)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 use parking_lot::Mutex;
 use tracing::debug;
 
-use data_types::{BigPipeValue, ServerMessage};
+use data_types::{BigPipeValue, ServerMessage, WalMessageEntry};
 use wal::{Wal, WAL_DEFAULT_ID};
 
 #[derive(Debug)]
@@ -85,7 +85,13 @@ impl BigPipe {
 
     /// Write to the underlying WAL.
     pub fn wal_write(&mut self, message: &ServerMessage) -> Result<(), Box<dyn std::error::Error>> {
-        self.wal.write(message)?;
+        // TODO: keep this as a WalOperation and allow callee to decide on inbound op?
+        self.wal
+            .write(data_types::WalOperation::Message(WalMessageEntry {
+                key: message.key().to_string(),
+                value: message.value(),
+                timestamp: message.timestamp() as u64,
+            }))?;
         Ok(())
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,10 +7,13 @@ use tracing::{debug, error, info};
 
 use crate::{
     data_types::{
-        proto::{
-            message_server::Message, namespace_server::Namespace, CreateNamespaceRequest,
-            CreateNamespaceResponse, ReadMessageRequest, ReadMessageResponse, SendMessageRequest,
-            SendMessageResponse, UpdateNamespaceRequest, UpdateNamespaceResponse,
+        message::{
+            message_server::Message, ReadMessageRequest, ReadMessageResponse, SendMessageRequest,
+            SendMessageResponse,
+        },
+        namespace::{
+            namespace_server::Namespace, CreateNamespaceRequest, CreateNamespaceResponse,
+            UpdateNamespaceRequest, UpdateNamespaceResponse,
         },
         BigPipeValue, RetentionPolicy, ServerMessage,
     },
@@ -151,12 +154,15 @@ mod test {
 
     use crate::{
         data_types::{
-            proto::{
-                message_server::Message, namespace_server::Namespace, CreateNamespaceRequest,
-                ReadMessageRequest, ReadMessageResponse, RetentionPolicy, SendMessageRequest,
-                SendMessageResponse, UpdateNamespaceRequest, UpdateNamespaceResponse,
+            message::{
+                message_server::Message, ReadMessageRequest, ReadMessageResponse,
+                SendMessageRequest, SendMessageResponse,
             },
-            ServerMessage,
+            namespace::{
+                namespace_server::Namespace, CreateNamespaceRequest, CreateNamespaceResponse,
+                UpdateNamespaceRequest, UpdateNamespaceResponse,
+            },
+            BigPipeValue, RetentionPolicy, ServerMessage,
         },
         server::BigPipeServer,
         BigPipe,

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -282,7 +282,7 @@ mod test {
 
         let mut wal = Wal::try_new(WAL_DEFAULT_ID, dir.path().to_path_buf(), None).unwrap();
 
-        wal.write(&ServerMessage::test_message(0)).unwrap();
+        wal.write(WalOperation::test_message(0)).unwrap();
         wal.flush().unwrap();
 
         assert!(wal.active_segment_path().exists());
@@ -297,13 +297,13 @@ mod test {
     fn write_with_rotation() {
         let dir = TempDir::new().unwrap();
 
-        let mut wal = Wal::try_new(WAL_DEFAULT_ID, dir.path().to_path_buf(), Some(16)).unwrap();
+        let mut wal = Wal::try_new(WAL_DEFAULT_ID, dir.path().to_path_buf(), Some(24)).unwrap();
 
         // Known size of the write
-        let server_msg_size = 15;
+        let server_msg_size = 17;
 
         for _ in 0..=2 {
-            wal.write(&ServerMessage::test_message(0)).unwrap();
+            wal.write(WalOperation::test_message(0)).unwrap();
             wal.flush().unwrap();
         }
 
@@ -338,7 +338,7 @@ mod test {
         .unwrap();
 
         for i in 0..100 {
-            wal.write(&ServerMessage::test_message(i)).unwrap();
+            wal.write(WalOperation::test_message(i)).unwrap();
             wal.active_segment.flush().unwrap();
         }
         wal.flush().unwrap();


### PR DESCRIPTION


- feat: include namespace creation for wal proto
- fix: use proto imports with correct module references
- feat: add wal op types
- feat: add namespace create entry to wal
- chore: update wal op types for tests
- chore: cleanup
