### PR TITLE
feat: wal per namespace

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -132,7 +132,10 @@ impl WalOperation {
                 value: msg.value,
                 timestamp: msg.timestamp,
             }),
-            WalOperation::Namespace(_) => todo!(),
+            WalOperation::Namespace(namespace) => WalOperation::Namespace(WalNamespaceEntry {
+                key: namespace.key,
+                retention_policy: namespace.retention_policy,
+            }),
         }
     }
 }

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -123,6 +123,18 @@ impl WalOperation {
             timestamp,
         })
     }
+
+    #[cfg(test)]
+    pub fn with_key(self, key: &str) -> Self {
+        match self {
+            WalOperation::Message(msg) => WalOperation::Message(WalMessageEntry {
+                key: key.to_string(),
+                value: msg.value,
+                timestamp: msg.timestamp,
+            }),
+            WalOperation::Namespace(_) => todo!(),
+        }
+    }
 }
 
 impl TryFrom<SegmentEntryProto> for WalOperation {

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -93,17 +93,20 @@ impl ServerMessage {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct WalMessageEntry {
     pub key: String,
     pub value: Bytes,
     pub timestamp: i64,
 }
 
+#[derive(Debug, Clone)]
 pub struct WalNamespaceEntry {
     pub key: String,
     pub retention_policy: RetentionPolicy,
 }
 
+#[derive(Debug, Clone)]
 pub enum WalOperation {
     /// Message ingest
     Message(WalMessageEntry),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ mod tests {
         let mut bigpipe = BigPipe::try_new(dir.path().to_path_buf(), None).unwrap();
 
         bigpipe.write(&ServerMessage::test_message(1)).unwrap();
-        bigpipe.wal.flush().unwrap();
+        bigpipe.wal.flush("hello").unwrap();
         drop(bigpipe); // drop to demonstrate replay capability
 
         let bigpipe = BigPipe::try_new(dir.path().to_path_buf(), None).unwrap();
@@ -152,7 +152,7 @@ mod tests {
         for i in 0..100 {
             bigpipe.write(&ServerMessage::test_message(i)).unwrap();
         }
-        bigpipe.wal.flush().unwrap();
+        bigpipe.wal.flush("hello").unwrap();
 
         assert_eq!(
             bigpipe.get_message_range("hello", 10).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use tracing::debug;
 
 use data_types::{BigPipeValue, ServerMessage, WalMessageEntry};
-use wal::{MultiWal, Wal, DEFAULT_MAX_SEGMENT_SIZE, WAL_DEFAULT_ID};
+use wal::MultiWal;
 
 #[derive(Debug)]
 pub struct BigPipe {

--- a/src/server.rs
+++ b/src/server.rs
@@ -208,7 +208,7 @@ mod test {
                 .write(&ServerMessage::test_message(i))
                 .unwrap();
         }
-        server.inner.lock().wal.flush().unwrap();
+        server.inner.lock().wal.flush("hello").unwrap();
 
         let messages = server
             .read(Request::new(ReadMessageRequest {

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -46,13 +46,8 @@ impl MultiWal {
     }
 
     /// Flush the [`Wal`] of a particular `key`.
-    pub(crate) fn flush(&self, namespace: &str) {
-        self.namespaces
-            .lock()
-            .get_mut(namespace)
-            .unwrap()
-            .flush()
-            .unwrap();
+    pub(crate) fn flush(&self, namespace: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(self.namespaces.lock().get_mut(namespace).unwrap().flush()?)
     }
 
     /// Flush all namespace [`Wal`]s.
@@ -79,10 +74,10 @@ impl MultiWal {
             });
     }
 
-    pub fn write(&self, op: WalOperation) {
+    pub fn write(&self, op: WalOperation) -> Result<(), Box<dyn std::error::Error>> {
         match &op {
-            WalOperation::Message(msg) => self.write_under_lock(&msg.key, &op),
-            WalOperation::Namespace(namespace) => self.write_under_lock(&namespace.key, &op),
+            WalOperation::Message(msg) => Ok(self.write_under_lock(&msg.key, &op)),
+            WalOperation::Namespace(namespace) => Ok(self.write_under_lock(&namespace.key, &op)),
         }
     }
 

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -37,17 +37,17 @@ impl MultiWal {
 
     /// Create the WAL directory structure that will be used for the underlying
     /// [`Wal`] for a particular key, returning the associated [`PathBuf`].
-    fn create_wal_directory(&self, key: &str) -> PathBuf {
-        let wal_dir = PathBuf::from(format!("{}/{key}", self.root_directory.display()));
+    fn create_wal_directory(&self, namespace: &str) -> PathBuf {
+        let wal_dir = PathBuf::from(format!("{}/{namespace}", self.root_directory.display()));
         std::fs::create_dir(&wal_dir).unwrap();
         wal_dir
     }
 
     /// Flush the [`Wal`] of a particular `key`.
-    pub(crate) fn flush(&self, key: &str) {
+    pub(crate) fn flush(&self, namespace: &str) {
         self.namespaces
             .lock()
-            .get_mut(key)
+            .get_mut(namespace)
             .unwrap()
             .flush()
             .unwrap();

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -23,14 +23,14 @@ pub(crate) const WAL_DEFAULT_ID: u64 = 0;
 
 #[derive(Debug)]
 pub struct MultiWal {
-    partitions: Arc<Mutex<HashMap<String, Wal>>>,
+    namespaces: Arc<Mutex<HashMap<String, Wal>>>,
     root_directory: PathBuf,
 }
 
 impl MultiWal {
     pub fn new(root_directory: PathBuf) -> Self {
         Self {
-            partitions: Arc::new(Mutex::new(HashMap::with_capacity(100))),
+            namespaces: Arc::new(Mutex::new(HashMap::with_capacity(100))),
             root_directory,
         }
     }
@@ -45,7 +45,7 @@ impl MultiWal {
 
     /// Flush the [`Wal`] of a particular `key`.
     pub(crate) fn flush(&self, key: &str) {
-        self.partitions
+        self.namespaces
             .lock()
             .get_mut(key)
             .unwrap()
@@ -56,7 +56,7 @@ impl MultiWal {
     pub fn write(&self, op: WalOperation) {
         match &op {
             WalOperation::Message(msg) => {
-                self.partitions
+                self.namespaces
                     .lock()
                     .entry(msg.key.clone())
                     .and_modify(|wal| {

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -46,13 +46,13 @@ impl MultiWal {
     }
 
     #[allow(dead_code)]
-    /// Flush the [`Wal`] of a particular `key`.
+    /// Flush the [`Wal`] of a particular namespace.
     pub(crate) fn flush(&self, namespace: &str) -> Result<(), Box<dyn std::error::Error>> {
         self.namespaces.lock().get_mut(namespace).unwrap().flush()
     }
 
     #[allow(dead_code)]
-    /// Flush all namespace [`Wal`]s.
+    /// Flush the [`Wal`] of all namespaces.
     pub(crate) fn flush_all(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.namespaces
             .lock()


### PR DESCRIPTION
Closes https://github.com/jdockerty/bigpipe/issues/27

This introduces a new layer of the WAL by adding a `MultiWal` which builds from the original `Wal` implementation. The `MultiWal` handles a `Wal` per namespace, ensuring that the writes for each namespace are isolated to their own directory and segment files.
