### PR TITLE
fix: wal usage wiring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 bytes = { version = "1.10.1", features = ["serde"] }
 chrono = { version = "0.4.41", features = ["serde"] }
-clap = { version = "4.5.38", features = ["derive", "env"] }
+clap = { version = "4.5.38", features = ["derive", "env", "string"] }
 clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
 hashbrown = "0.15.3"
 parking_lot = "0.12.3"

--- a/src/bin/bigpipe.rs
+++ b/src/bin/bigpipe.rs
@@ -63,7 +63,7 @@ enum Commands {
         addr: String,
 
         /// Directory where the write-ahead log (WAL) files will be written to.
-        #[arg(long, env = "BIGPIPE_WAL_DIRECTORY", default_value = "./")]
+        #[arg(long, env = "BIGPIPE_WAL_DIRECTORY", default_value = default_wal_directory().into_os_string() )]
         wal_directory: PathBuf,
 
         /// Max size of a segment for the WAL.
@@ -73,6 +73,10 @@ enum Commands {
         #[command(flatten)]
         verbosity: Verbosity<InfoLevel>,
     },
+}
+
+fn default_wal_directory() -> PathBuf {
+    std::env::temp_dir().join("bigpipe")
 }
 
 #[tokio::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ impl BigPipe {
         wal_directory: PathBuf,
         wal_max_segment_size: Option<usize>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        if !wal_directory.exists() {
+            std::fs::create_dir_all(&wal_directory)?;
+        }
         let inner = Mutex::new(MultiWal::replay(&wal_directory));
         let wal = MultiWal::new(wal_directory, wal_max_segment_size);
         Ok(Self { wal, inner })


### PR DESCRIPTION
Helps https://github.com/jdockerty/bigpipe/issues/27

Small fix for moving away from the current directory (`./`) for the WAL directory.

Since the `MultiWal` tries to walk, via `replay`, the given directory, it is likely that the current
directory has files that are not relating to segment files or directories. These can be filtered out,
but for now it is simpler to ensure that the values given are sane by default.
