### PR TITLE
fix: remove double mutex

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -107,7 +107,7 @@ impl Namespace for Arc<BigPipeServer> {
             retention_policy: _,
         } = request.into_inner();
 
-        match self.inner.lock().inner.lock().entry(key.clone()) {
+        match self.inner.lock().inner.entry(key.clone()) {
             hashbrown::hash_map::Entry::Occupied(_) => Err(Status::new(
                 Code::AlreadyExists,
                 format!("{key} already exists"),
@@ -130,7 +130,7 @@ impl Namespace for Arc<BigPipeServer> {
 
         let retention_policy = RetentionPolicy::try_from(retention_policy).unwrap();
 
-        match self.inner.lock().inner.lock().get_key_value_mut(&key) {
+        match self.inner.lock().inner.get_key_value_mut(&key) {
             Some((_, value)) => {
                 value.set_retention_policy(retention_policy);
                 Ok(Response::new(UpdateNamespaceResponse { key }))


### PR DESCRIPTION
From the server perspective, the `BigPipe` type is already behind a mutex, so we do not need to put the `HashMap` behind one too.
