### PR TITLE
refactor: rename multi wal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 use tracing::debug;
 
 use data_types::{BigPipeValue, ServerMessage, WalMessageEntry};
-use wal::MultiWal;
+use wal::NamespaceWal;
 
 #[derive(Debug)]
 pub struct BigPipe {
@@ -16,7 +16,7 @@ pub struct BigPipe {
     /// partitioned by their key.
     inner: HashMap<String, BigPipeValue>,
     /// Write ahead log to ensure durability of writes.
-    wal: MultiWal,
+    wal: NamespaceWal,
 }
 
 impl BigPipe {
@@ -27,8 +27,8 @@ impl BigPipe {
         if !wal_directory.exists() {
             std::fs::create_dir_all(&wal_directory)?;
         }
-        let inner = MultiWal::replay(&wal_directory);
-        let wal = MultiWal::new(wal_directory, wal_max_segment_size);
+        let inner = NamespaceWal::replay(&wal_directory);
+        let wal = NamespaceWal::new(wal_directory, wal_max_segment_size);
         Ok(Self { wal, inner })
     }
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -3,7 +3,7 @@ mod multi;
 /// Write-ahead log implementation.
 mod single;
 
-pub use multi::MultiWal;
+pub use multi::NamespaceWal;
 use single::Wal;
 
 pub(crate) const DEFAULT_MAX_SEGMENT_SIZE: usize = 16777216; // 16 MiB


### PR DESCRIPTION
This multi WAL implementation can be better named to a `NamespaceWal` to identify that it is relating to a namespace-scoped WAL.
