### PR TITLE
fix: replay after active namespace

### DIFF
--- a/src/wal/multi.rs
+++ b/src/wal/multi.rs
@@ -28,7 +28,8 @@ pub struct NamespaceWal {
     /// Distribution of time taken for different kinds
     /// of writes to be applied to the underlying WAL.
     wal_write_duration: HistogramVec,
-
+    /// Distribution of time taken for a WAL replay
+    /// to complete.
     wal_replay_duration: HistogramVec,
 }
 

--- a/src/wal/multi.rs
+++ b/src/wal/multi.rs
@@ -105,6 +105,10 @@ impl NamespaceWal {
             .try_for_each(|(_, wal)| wal.flush())
     }
 
+    /// Write the incoming operation for a namespace whilst taking
+    /// the internal namespace lock.
+    ///
+    /// When a namespace does not exist, it is eagerly created.
     fn write_under_lock(&self, namespace: &str, op: &WalOperation) {
         self.namespaces
             .lock()


### PR DESCRIPTION
Before this, the `create_wal_directory` would run
and panic because no notion of the directoy already
being created is tracked.

This changes the `replay` function such that it is
no longer independent of the `NamespaceWal` and
instead populates the internal `namespaces` mapping
of known namespaces as the replay occurs.
