### PR TITLE
feat: retention enforcement

### DIFF
--- a/src/bin/bigpipe.rs
+++ b/src/bin/bigpipe.rs
@@ -20,6 +20,7 @@ use bigpipe::{
     server::BigPipeServer,
     BigPipe,
 };
+use tracing::info;
 
 #[derive(Parser)]
 struct Cli {
@@ -133,11 +134,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             tracing_subscriber::fmt().with_max_level(verbosity).init();
             let metrics = Registry::new();
+            info!(log_directory = %wal_directory.display(), max_segment_size = wal_segment_max_size, bind_address = addr, metrics_bind_address = metrics_addr, "starting bigpipe");
             let bigpipe = BigPipe::try_new(wal_directory.clone(), wal_segment_max_size, &metrics)?;
             let bigpipe_server = Arc::new(BigPipeServer::new(bigpipe, &metrics));
 
             bigpipe::run_metrics_task(&metrics_addr, metrics).await?;
 
+            info!("started bigpipe");
             Server::builder()
                 .add_service(MessageServer::new(Arc::clone(&bigpipe_server)))
                 .add_service(NamespaceServer::new(Arc::clone(&bigpipe_server)))

--- a/src/data_types/namespace.rs
+++ b/src/data_types/namespace.rs
@@ -25,6 +25,10 @@ impl Namespace {
     pub fn new(namespace: &str) -> Self {
         Self(Arc::new(namespace.to_string()))
     }
+
+    pub fn inner(&self) -> &str {
+        &self.0
+    }
 }
 
 impl Clone for Namespace {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,17 @@ impl BigPipe {
         self.log.contains_namespace(namespace)
     }
 
-    pub fn create_namespace(&mut self, namespace: Namespace) {
+    pub fn create_namespace(
+        &mut self,
+        namespace: Namespace,
+        retention_config: Option<RetentionConfig>,
+    ) {
         self.log.create_namespace(&namespace);
         let path = self.log.root_directory().join(namespace.inner());
         self.retention_manager.add_namespace(
             namespace,
             path.clone(),
-            RetentionConfig::default(),
+            retention_config.unwrap_or_default(),
             move || find_segment_ids(path.clone()),
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod retention;
 pub mod server;
 
 pub use metrics::run_metrics_task;
+use retention::{RetentionConfig, RetentionManager};
 
 use std::path::PathBuf;
 
@@ -13,7 +14,7 @@ use hashbrown::HashMap;
 use prometheus::{IntCounter, Registry};
 
 use data_types::{message::ServerMessage, namespace::Namespace};
-use log::MultiLog;
+use log::{find_segment_ids, MultiLog};
 
 #[derive(Debug)]
 pub struct BigPipe {
@@ -22,6 +23,9 @@ pub struct BigPipe {
     /// This is composed of multiple [`ScopedLog`]s, partitioned by
     /// [`Namespace`] to isolate data.
     log: MultiLog,
+
+    /// Handle retention enforcement across numerous namespaces.
+    retention_manager: RetentionManager,
 
     /// Total number of messages received throughout the process
     /// lifetime.
@@ -49,8 +53,10 @@ impl BigPipe {
             .unwrap();
 
         let log = MultiLog::new(wal_directory, wal_max_segment_size, metrics);
+        let retention_manager = RetentionManager::new();
         Ok(Self {
             log,
+            retention_manager,
             received_messages,
         })
     }
@@ -62,6 +68,19 @@ impl BigPipe {
     pub fn write(&mut self, message: &ServerMessage) -> Result<(), Box<dyn std::error::Error>> {
         self.log.write(message)?;
         self.log.flush(&Namespace::new(message.key()))?;
+
+        if !self
+            .retention_manager
+            .contains_namespace(&Namespace::new(message.key()))
+        {
+            let namespace_path = self.log.root_directory().join(message.key());
+            self.retention_manager.add_namespace(
+                Namespace::new(message.key()),
+                namespace_path.clone(),
+                RetentionConfig::default(),
+                move || find_segment_ids(namespace_path.clone()),
+            )
+        }
         self.received_messages.inc();
         Ok(())
     }
@@ -88,6 +107,13 @@ impl BigPipe {
 
     pub fn create_namespace(&mut self, namespace: Namespace) {
         self.log.create_namespace(&namespace);
+        let path = self.log.root_directory().join(namespace.inner());
+        self.retention_manager.add_namespace(
+            namespace,
+            path.clone(),
+            RetentionConfig::default(),
+            move || find_segment_ids(path.clone()),
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl BigPipe {
                 namespace_path.clone(),
                 RetentionConfig::default(),
                 move || find_segment_ids(namespace_path.clone()),
-            )
+            );
         }
         self.received_messages.inc();
         Ok(())
@@ -113,7 +113,7 @@ impl BigPipe {
             path.clone(),
             RetentionConfig::default(),
             move || find_segment_ids(path.clone()),
-        )
+        );
     }
 }
 
@@ -124,8 +124,8 @@ mod tests {
 
     use crate::{data_types::namespace::Namespace, BigPipe, ServerMessage};
 
-    #[test]
-    fn add_messages() {
+    #[tokio::test]
+    async fn add_messages() {
         let wal_dir = TempDir::new().unwrap();
         let metrics = Registry::new();
         let mut q = BigPipe::try_new(wal_dir.path().to_path_buf(), None, &metrics).unwrap();
@@ -186,8 +186,8 @@ mod tests {
     //     );
     // }
 
-    #[test]
-    fn message_range() {
+    #[tokio::test]
+    async fn message_range() {
         let dir = TempDir::new().unwrap();
         let metrics = Registry::new();
         let mut bigpipe = BigPipe::try_new(dir.path().to_path_buf(), None, &metrics).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod data_types;
 mod log;
 mod metrics;
+mod retention;
 pub mod server;
 
 pub use metrics::run_metrics_task;

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -9,5 +9,5 @@ pub use single::{find_segment_ids, SegmentId};
 pub(crate) const DEFAULT_MAX_SEGMENT_SIZE: usize = 16777216; // 16 MiB
 const MAX_SEGMENT_BUFFER_SIZE: u16 = 8192; // 8 KiB
 
-const WAL_EXTENSION: &str = "-bp.wal";
+pub const WAL_EXTENSION: &str = "-bp.wal";
 pub(crate) const WAL_DEFAULT_ID: u64 = 0;

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -4,6 +4,7 @@ mod multi;
 mod single;
 
 pub use multi::MultiLog;
+pub use single::SegmentId;
 
 pub(crate) const DEFAULT_MAX_SEGMENT_SIZE: usize = 16777216; // 16 MiB
 const MAX_SEGMENT_BUFFER_SIZE: u16 = 8192; // 8 KiB

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -4,7 +4,7 @@ mod multi;
 mod single;
 
 pub use multi::MultiLog;
-pub use single::SegmentId;
+pub use single::{find_segment_ids, SegmentId};
 
 pub(crate) const DEFAULT_MAX_SEGMENT_SIZE: usize = 16777216; // 16 MiB
 const MAX_SEGMENT_BUFFER_SIZE: u16 = 8192; // 8 KiB

--- a/src/log/multi.rs
+++ b/src/log/multi.rs
@@ -6,6 +6,7 @@ use hashbrown::HashMap;
 use parking_lot::Mutex;
 use prometheus::{Histogram, HistogramOpts, HistogramVec, IntCounter, Registry};
 use tokio::time::Instant;
+use tracing::info;
 use walkdir::WalkDir;
 
 use super::single::ScopedLog;
@@ -81,6 +82,12 @@ impl MultiLog {
             max_segment_size,
             wal_replay_duration.clone(),
         );
+        total_namespaces.inc_by(namespaces.keys().len() as u64);
+
+        info!(
+            namespaces_found = total_namespaces.get(),
+            "full log replay complete"
+        );
 
         Self {
             namespaces: Arc::new(Mutex::new(namespaces)),
@@ -94,6 +101,10 @@ impl MultiLog {
 
     pub fn namespaces(&self) -> Vec<Namespace> {
         self.namespaces.lock().keys().cloned().collect()
+    }
+
+    pub fn root_directory(&self) -> &Path {
+        &self.root_directory
     }
 
     #[allow(dead_code)]
@@ -230,6 +241,7 @@ fn replay(
                     .to_string_lossy()
                     .as_ref(),
             );
+            info!(%namespace, "replaying log file");
             timer.stop_and_record();
             multi_log.insert(namespace, log);
         }

--- a/src/log/single.rs
+++ b/src/log/single.rs
@@ -349,7 +349,7 @@ impl Segment {
     }
 }
 
-fn find_segment_ids(path: impl AsRef<Path>) -> Vec<SegmentId> {
+pub fn find_segment_ids(path: impl AsRef<Path>) -> Vec<SegmentId> {
     let dir = walkdir::WalkDir::new(&path)
         .max_depth(1)
         .into_iter()

--- a/src/log/single.rs
+++ b/src/log/single.rs
@@ -246,7 +246,16 @@ impl ScopedLog {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct SegmentId(u64);
+pub struct SegmentId(u64);
+
+impl SegmentId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
 
 #[derive(Debug)]
 struct Segment {
@@ -305,7 +314,7 @@ impl Segment {
         Ok((size, byte_offset))
     }
 
-    fn id(&self) -> u64 {
+    pub fn id(&self) -> u64 {
         self.id.0
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use prometheus::{Encoder, Registry, TextEncoder};
 use tokio::net::TcpListener;
-use tracing::debug;
+use tracing::{debug, info};
 
 #[derive(Clone)]
 struct HttpState {
@@ -23,6 +23,7 @@ pub async fn run_metrics_task(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let metrics_listener = TcpListener::bind(metrics_addr).await?;
     tokio::spawn(async move {
+        info!("started metrics task");
         let router = Router::new()
             .route("/metrics", get(metrics_handler))
             .with_state(HttpState { metrics });

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -323,8 +323,8 @@ mod tests {
         assert_eq!(to_delete[0].get(), 1);
     }
 
-    #[test]
-    fn retention_manager() {
+    #[tokio::test]
+    async fn retention_manager() {
         let dir = TempDir::new().unwrap();
         let namespace = Namespace::new("test");
         let namespace_dir = dir.path().join("test");

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,0 +1,64 @@
+use std::{path::PathBuf, time::Duration};
+
+use hashbrown::HashMap;
+use tokio::{
+    sync::mpsc::{self, Sender},
+    task::JoinHandle,
+};
+use tracing::{info, warn};
+
+use crate::data_types::namespace::Namespace;
+
+pub struct RetentionManager {
+    namespaces: HashMap<Namespace, RetentionWorker>,
+}
+
+impl RetentionManager {
+    pub fn new(namespaces: impl Iterator<Item = Namespace>, log_directory: PathBuf) -> Self {
+        Self {
+            namespaces: HashMap::from_iter(namespaces.map(|n| {
+                (
+                    n.clone(),
+                    RetentionWorker::new(log_directory.join(n.inner())),
+                )
+            })),
+        }
+    }
+}
+
+struct RetentionWorker {
+    directory: PathBuf,
+    task: JoinHandle<()>,
+}
+
+impl RetentionWorker {
+    pub fn new(directory: PathBuf) -> Self {
+        let task = tokio::spawn(run_retention(directory.clone()));
+        Self { directory, task }
+    }
+}
+
+async fn run_retention(directory: PathBuf) {
+    info!(directory = %directory.display(), "starting retention task");
+    loop {
+        tokio::select! {
+            _ = run_disk_pressure(directory.clone()) => warn!(directory = %directory.display(), "stopping disk pressure"),
+            _ = run_ttl(directory.clone()) => warn!(directory = %directory.display(), "stopping tll"),
+        }
+    }
+}
+
+async fn run_disk_pressure(directory: PathBuf) {
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    let max_size: u64 = 1024 * 1024;
+    // TODO: pass closed segments via channel?
+    loop {
+        interval.tick().await;
+    }
+}
+async fn run_ttl(directory: PathBuf) {
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    loop {
+        interval.tick().await;
+    }
+}

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -6,9 +6,14 @@ use std::time::{Duration, SystemTime};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
+use crate::log::WAL_EXTENSION;
 use crate::{data_types::namespace::Namespace, log::SegmentId};
 
-/// Configuration for retention policies
+pub const DEFAULT_RETENTION_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
+pub const DEFAULT_RETENTION_MAX_AGE: Duration = Duration::from_secs(4 * 60 * 60); // 4 hours
+pub const DEFAULT_RETENTION_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Configuration for retention
 #[derive(Debug, Clone)]
 pub struct RetentionConfig {
     /// Maximum total size in bytes for all segments
@@ -19,12 +24,22 @@ pub struct RetentionConfig {
     pub check_interval: Duration,
 }
 
+impl RetentionConfig {
+    pub fn new(max_bytes: u64, max_age: Duration, check_interval: Duration) -> Self {
+        Self {
+            max_bytes: Some(max_bytes),
+            max_age: Some(max_age),
+            check_interval,
+        }
+    }
+}
+
 impl Default for RetentionConfig {
     fn default() -> Self {
         Self {
-            max_bytes: Some(1024 * 1024 * 1024),             // 1GiB
-            max_age: Some(Duration::from_secs(4 * 60 * 60)), // 4 hours
-            check_interval: Duration::from_secs(60),         // Every minute
+            max_bytes: Some(DEFAULT_RETENTION_MAX_BYTES),
+            max_age: Some(DEFAULT_RETENTION_MAX_AGE),
+            check_interval: DEFAULT_RETENTION_CHECK_INTERVAL,
         }
     }
 }
@@ -152,7 +167,8 @@ impl RetentionEnforcer {
     }
 
     fn segment_path(&self, segment: &SegmentId) -> PathBuf {
-        self.directory.join(format!("{}-bp.wal", segment.get()))
+        self.directory
+            .join(format!("{}{WAL_EXTENSION}", segment.get()))
     }
 }
 

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -187,7 +187,7 @@ impl RetentionManager {
 
     /// Start retention for a new [`Namespace`].
     pub fn add_namespace(
-        &mut self,
+        &self,
         namespace: Namespace,
         log_directory: PathBuf,
         config: RetentionConfig,
@@ -242,10 +242,14 @@ impl RetentionManager {
             .insert(namespace.clone(), (policy, handle));
     }
 
-    /// Stop retention management for a namespace
-    pub fn remove_namespace(&mut self, namespace: &Namespace) {
+    /// Stop retention management for a namespace, returning the [`Namespace`] if it
+    /// has been removed from retention management.
+    pub fn remove_namespace(&self, namespace: &Namespace) -> Option<Namespace> {
         if let Some((_, handle)) = self.enforcers.write().remove(namespace) {
             handle.abort();
+            Some(namespace.clone())
+        } else {
+            None
         }
     }
 
@@ -255,17 +259,17 @@ impl RetentionManager {
 
     /// Force a retention check against a namespace and specified
     /// segments.
-    pub(crate) fn check_retention(
+    fn check_retention(
         &self,
         namespace: &Namespace,
         segments: &[SegmentId],
-    ) -> Result<Vec<SegmentId>, std::io::Error> {
+    ) -> Result<Option<Vec<SegmentId>>, std::io::Error> {
         let policies = self.enforcers.read();
 
         if let Some((policy, _)) = policies.get(namespace) {
-            policy.evaluate(segments)
+            policy.evaluate(segments).map(|s| Some(s))
         } else {
-            Ok(Vec::new())
+            Ok(None)
         }
     }
 }
@@ -359,15 +363,23 @@ mod tests {
 
         let manager = RetentionManager::new();
 
-        manager.enforcers.write().insert(
+        manager.add_namespace(
             namespace.clone(),
-            (
-                RetentionEnforcer::new(namespace_dir, config),
-                tokio::task::spawn(async move {}),
-            ),
+            namespace_dir.clone(),
+            config.clone(),
+            || vec![],
         );
 
         let to_delete = manager.check_retention(&namespace, &segments).unwrap();
-        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete.expect("contains namespace").len(), 1);
+        assert_eq!(manager.remove_namespace(&namespace), Some(namespace));
+
+        let not_exist = manager
+            .check_retention(&Namespace::new("not_exists"), &segments)
+            .unwrap();
+        assert!(
+            not_exist.is_none(),
+            "Should return None for non-existent namespace"
+        );
     }
 }

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,8 +1,9 @@
 use hashbrown::HashMap;
+use parking_lot::RwLock;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use crate::{data_types::namespace::Namespace, log::SegmentId};
@@ -28,7 +29,9 @@ impl Default for RetentionConfig {
     }
 }
 
-/// Core retention policy enforcement
+/// A [`RetentionEnforcer`] will enforce the disk pressure and time-to-live (TTL)
+/// policy over a namespace contained at the specified directory.
+#[derive(Clone)]
 pub struct RetentionEnforcer {
     config: RetentionConfig,
     directory: PathBuf,
@@ -55,11 +58,6 @@ impl RetentionEnforcer {
             let deletions = self.apply_time_retention(segments, max_age)?;
             segments_to_delete.extend(deletions);
         }
-
-        // Deduplicate
-        segments_to_delete.sort();
-        segments_to_delete.dedup();
-
         Ok(segments_to_delete)
     }
 
@@ -157,17 +155,15 @@ impl RetentionEnforcer {
     }
 }
 
-/// Manager for retention across multiple namespaces
+/// Manager for retention enforcement across multiple namespaces.
 pub struct RetentionManager {
-    policies: Arc<RwLock<HashMap<Namespace, RetentionEnforcer>>>,
-    handles: HashMap<Namespace, tokio::task::JoinHandle<()>>,
+    enforcers: Arc<RwLock<HashMap<Namespace, (RetentionEnforcer, JoinHandle<()>)>>>,
 }
 
 impl RetentionManager {
     pub fn new() -> Self {
         Self {
-            policies: Arc::new(RwLock::new(HashMap::new())),
-            handles: HashMap::new(),
+            enforcers: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -182,18 +178,10 @@ impl RetentionManager {
         let directory = log_directory.join(namespace.inner());
         let policy = RetentionEnforcer::new(directory.clone(), config.clone());
 
-        self.policies
-            .write()
-            .await
-            .insert(namespace.clone(), policy);
-
-        let policies = Arc::clone(&self.policies);
-        let namespace_clone = namespace.clone();
-
-        // Spawn background task for this namespace
+        let policy_internal = policy.clone();
+        let namespace_internal = namespace.clone();
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(config.check_interval);
-
             loop {
                 interval.tick().await;
 
@@ -202,45 +190,43 @@ impl RetentionManager {
                     continue;
                 }
 
-                // Get policy and evaluate
-                let policies = policies.read().await;
-                if let Some(policy) = policies.get(&namespace_clone) {
-                    match policy.evaluate(&segments) {
-                        Ok(to_delete) => {
-                            if !to_delete.is_empty() {
-                                info!(
-                                    namespace = %namespace_clone.inner(),
-                                    count = to_delete.len(),
-                                    "Applying retention policy"
-                                );
+                match policy_internal.evaluate(&segments) {
+                    Ok(to_delete) => {
+                        if !to_delete.is_empty() {
+                            info!(
+                                namespace = %namespace_internal.clone().inner(),
+                                count = to_delete.len(),
+                                "Applying retention policy"
+                            );
 
-                                if let Err(e) = policy.delete_segments(&to_delete) {
-                                    warn!(
-                                        namespace = %namespace_clone.inner(),
-                                        error = %e,
-                                        "Failed to delete segments"
-                                    );
-                                }
+                            if let Err(e) = policy_internal.delete_segments(&to_delete) {
+                                warn!(
+                                    namespace = %namespace_internal.inner(),
+                                    error = %e,
+                                    "Failed to delete segments"
+                                );
                             }
                         }
-                        Err(e) => {
-                            warn!(
-                                namespace = %namespace_clone.inner(),
-                                error = %e,
-                                "Failed to evaluate retention policy"
-                            );
-                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            namespace = %namespace_internal.inner(),
+                            error = %e,
+                            "Failed to evaluate retention policy"
+                        );
                     }
                 }
             }
         });
 
-        self.handles.insert(namespace, handle);
+        self.enforcers
+            .write()
+            .insert(namespace.clone(), (policy, handle));
     }
 
     /// Stop retention management for a namespace
     pub fn remove_namespace(&mut self, namespace: &Namespace) {
-        if let Some(handle) = self.handles.remove(namespace) {
+        if let Some((_, handle)) = self.enforcers.write().remove(namespace) {
             handle.abort();
         }
     }
@@ -252,9 +238,9 @@ impl RetentionManager {
         namespace: &Namespace,
         segments: &[SegmentId],
     ) -> Result<Vec<SegmentId>, std::io::Error> {
-        let policies = self.policies.read().await;
+        let policies = self.enforcers.read();
 
-        if let Some(policy) = policies.get(namespace) {
+        if let Some((policy, _)) = policies.get(namespace) {
             policy.evaluate(segments)
         } else {
             Ok(Vec::new())
@@ -351,9 +337,12 @@ mod tests {
 
         let manager = RetentionManager::new();
 
-        manager.policies.write().await.insert(
+        manager.enforcers.write().insert(
             namespace.clone(),
-            RetentionEnforcer::new(namespace_dir, config),
+            (
+                RetentionEnforcer::new(namespace_dir, config),
+                tokio::task::spawn(async move {}),
+            ),
         );
 
         let to_delete = manager

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -21,9 +21,9 @@ pub struct RetentionConfig {
 impl Default for RetentionConfig {
     fn default() -> Self {
         Self {
-            max_bytes: Some(1024 * 1024 * 1024),               // 1GB default
-            max_age: Some(Duration::from_secs(7 * 24 * 3600)), // 7 days
-            check_interval: Duration::from_secs(60),           // Check every minute
+            max_bytes: Some(1024 * 1024 * 1024),             // 1GiB
+            max_age: Some(Duration::from_secs(4 * 60 * 60)), // 4 hours
+            check_interval: Duration::from_secs(60),         // Every minute
         }
     }
 }

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,64 +1,365 @@
-use std::{path::PathBuf, time::Duration};
-
 use hashbrown::HashMap;
-use tokio::{
-    sync::mpsc::{self, Sender},
-    task::JoinHandle,
-};
-use tracing::{info, warn};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
 
-use crate::data_types::namespace::Namespace;
+use crate::{data_types::namespace::Namespace, log::SegmentId};
 
+/// Configuration for retention policies
+#[derive(Debug, Clone)]
+pub struct RetentionConfig {
+    /// Maximum total size in bytes for all segments
+    pub max_bytes: Option<u64>,
+    /// Maximum age for segments before deletion
+    pub max_age: Option<Duration>,
+    /// How often to check retention policies
+    pub check_interval: Duration,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            max_bytes: Some(1024 * 1024 * 1024),               // 1GB default
+            max_age: Some(Duration::from_secs(7 * 24 * 3600)), // 7 days
+            check_interval: Duration::from_secs(60),           // Check every minute
+        }
+    }
+}
+
+/// Core retention policy enforcement
+pub struct RetentionEnforcer {
+    config: RetentionConfig,
+    directory: PathBuf,
+}
+
+impl RetentionEnforcer {
+    pub fn new(directory: PathBuf, config: RetentionConfig) -> Self {
+        Self { directory, config }
+    }
+
+    /// Apply retention policy to a list of closed segments
+    /// Returns segments that should be deleted
+    pub fn evaluate(&self, segments: &[SegmentId]) -> Result<Vec<SegmentId>, std::io::Error> {
+        let mut segments_to_delete = Vec::new();
+
+        // Apply disk pressure retention if configured
+        if let Some(max_bytes) = self.config.max_bytes {
+            let deletions = self.apply_size_retention(segments, max_bytes)?;
+            segments_to_delete.extend(deletions);
+        }
+
+        // Apply TTL retention if configured
+        if let Some(max_age) = self.config.max_age {
+            let deletions = self.apply_time_retention(segments, max_age)?;
+            segments_to_delete.extend(deletions);
+        }
+
+        // Deduplicate
+        segments_to_delete.sort();
+        segments_to_delete.dedup();
+
+        Ok(segments_to_delete)
+    }
+
+    /// Delete segments based on total size limit
+    fn apply_size_retention(
+        &self,
+        segments: &[SegmentId],
+        max_bytes: u64,
+    ) -> Result<Vec<SegmentId>, std::io::Error> {
+        let mut segments_with_size: Vec<(SegmentId, u64)> = Vec::new();
+        let mut total_size = 0;
+
+        // Get size and modification time for each segment
+        for segment in segments {
+            let path = self.segment_path(segment);
+            let metadata = std::fs::metadata(&path)?;
+            let size = metadata.len();
+
+            segments_with_size.push((segment.clone(), size));
+            total_size += size;
+        }
+
+        if total_size <= max_bytes {
+            return Ok(Vec::new());
+        }
+
+        // Sort by [`SegmentId`] as these are monotonically increasing and
+        // implies older segments have a lower ID value.
+        segments_with_size.sort_by_key(|(id, _)| id.get());
+
+        let mut to_delete = Vec::new();
+        let mut bytes_to_free = total_size - max_bytes;
+
+        for (segment, size) in segments_with_size {
+            if bytes_to_free == 0 {
+                break;
+            }
+
+            to_delete.push(segment.clone());
+            bytes_to_free = bytes_to_free.saturating_sub(size);
+
+            debug!(
+                segment = ?segment,
+                size_bytes = size,
+                "Marking segment for deletion due to size limit"
+            );
+        }
+
+        Ok(to_delete)
+    }
+
+    /// Delete segments based on ttl
+    fn apply_time_retention(
+        &self,
+        segments: &[SegmentId],
+        max_age: Duration,
+    ) -> Result<Vec<SegmentId>, std::io::Error> {
+        let mut to_delete = Vec::new();
+        let now = SystemTime::now();
+
+        for segment in segments {
+            let path = self.segment_path(segment);
+            let metadata = std::fs::metadata(&path)?;
+            let modified = metadata.modified()?;
+
+            if let Ok(age) = now.duration_since(modified) {
+                if age > max_age {
+                    to_delete.push(segment.clone());
+                    debug!(
+                        segment = ?segment,
+                        age_seconds = age.as_secs(),
+                        "Marking segment for deletion due to ttl"
+                    );
+                }
+            }
+        }
+
+        Ok(to_delete)
+    }
+
+    /// Delete the specified segments from disk
+    pub fn delete_segments(&self, segments: &[SegmentId]) -> Result<(), std::io::Error> {
+        for segment in segments {
+            let path = self.segment_path(segment);
+            if path.exists() {
+                std::fs::remove_file(&path)?;
+                info!(segment = ?segment, "Deleted segment");
+            }
+        }
+        Ok(())
+    }
+
+    fn segment_path(&self, segment: &SegmentId) -> PathBuf {
+        self.directory.join(format!("{}-bp.wal", segment.get()))
+    }
+}
+
+/// Manager for retention across multiple namespaces
 pub struct RetentionManager {
-    namespaces: HashMap<Namespace, RetentionWorker>,
+    policies: Arc<RwLock<HashMap<Namespace, RetentionEnforcer>>>,
+    handles: HashMap<Namespace, tokio::task::JoinHandle<()>>,
 }
 
 impl RetentionManager {
-    pub fn new(namespaces: impl Iterator<Item = Namespace>, log_directory: PathBuf) -> Self {
+    pub fn new() -> Self {
         Self {
-            namespaces: HashMap::from_iter(namespaces.map(|n| {
-                (
-                    n.clone(),
-                    RetentionWorker::new(log_directory.join(n.inner())),
-                )
-            })),
+            policies: Arc::new(RwLock::new(HashMap::new())),
+            handles: HashMap::new(),
+        }
+    }
+
+    /// Start retention for a new [`Namespace`].
+    pub async fn add_namespace(
+        &mut self,
+        namespace: Namespace,
+        log_directory: PathBuf,
+        config: RetentionConfig,
+        segment_provider: impl Fn() -> Vec<SegmentId> + Send + Sync + 'static,
+    ) {
+        let directory = log_directory.join(namespace.inner());
+        let policy = RetentionEnforcer::new(directory.clone(), config.clone());
+
+        self.policies
+            .write()
+            .await
+            .insert(namespace.clone(), policy);
+
+        let policies = Arc::clone(&self.policies);
+        let namespace_clone = namespace.clone();
+
+        // Spawn background task for this namespace
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(config.check_interval);
+
+            loop {
+                interval.tick().await;
+
+                let segments = segment_provider();
+                if segments.is_empty() {
+                    continue;
+                }
+
+                // Get policy and evaluate
+                let policies = policies.read().await;
+                if let Some(policy) = policies.get(&namespace_clone) {
+                    match policy.evaluate(&segments) {
+                        Ok(to_delete) => {
+                            if !to_delete.is_empty() {
+                                info!(
+                                    namespace = %namespace_clone.inner(),
+                                    count = to_delete.len(),
+                                    "Applying retention policy"
+                                );
+
+                                if let Err(e) = policy.delete_segments(&to_delete) {
+                                    warn!(
+                                        namespace = %namespace_clone.inner(),
+                                        error = %e,
+                                        "Failed to delete segments"
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                namespace = %namespace_clone.inner(),
+                                error = %e,
+                                "Failed to evaluate retention policy"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+
+        self.handles.insert(namespace, handle);
+    }
+
+    /// Stop retention management for a namespace
+    pub fn remove_namespace(&mut self, namespace: &Namespace) {
+        if let Some(handle) = self.handles.remove(namespace) {
+            handle.abort();
+        }
+    }
+
+    /// Force a retention check against a namespace and specified
+    /// segments.
+    pub async fn check_retention(
+        &self,
+        namespace: &Namespace,
+        segments: &[SegmentId],
+    ) -> Result<Vec<SegmentId>, std::io::Error> {
+        let policies = self.policies.read().await;
+
+        if let Some(policy) = policies.get(namespace) {
+            policy.evaluate(segments)
+        } else {
+            Ok(Vec::new())
         }
     }
 }
 
-struct RetentionWorker {
-    directory: PathBuf,
-    task: JoinHandle<()>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::TempDir;
 
-impl RetentionWorker {
-    pub fn new(directory: PathBuf) -> Self {
-        let task = tokio::spawn(run_retention(directory.clone()));
-        Self { directory, task }
-    }
-}
+    fn create_test_segment(dir: &Path, id: u64, size: usize, age_secs: u64) -> SegmentId {
+        let path = dir.join(format!("{}-bp.wal", id));
+        let mut file = File::create(&path).unwrap();
+        // Write junk data, it doesn't have to be a [`ServerMessage`]
+        // for retention tests.
+        file.write_all(&vec![0u8; size]).unwrap();
+        file.sync_all().unwrap();
 
-async fn run_retention(directory: PathBuf) {
-    info!(directory = %directory.display(), "starting retention task");
-    loop {
-        tokio::select! {
-            _ = run_disk_pressure(directory.clone()) => warn!(directory = %directory.display(), "stopping disk pressure"),
-            _ = run_ttl(directory.clone()) => warn!(directory = %directory.display(), "stopping tll"),
-        }
-    }
-}
+        let modified_time = SystemTime::now() - Duration::from_secs(age_secs);
+        file.set_modified(modified_time).unwrap();
 
-async fn run_disk_pressure(directory: PathBuf) {
-    let mut interval = tokio::time::interval(Duration::from_secs(1));
-    let max_size: u64 = 1024 * 1024;
-    // TODO: pass closed segments via channel?
-    loop {
-        interval.tick().await;
+        SegmentId::new(id)
     }
-}
-async fn run_ttl(directory: PathBuf) {
-    let mut interval = tokio::time::interval(Duration::from_secs(1));
-    loop {
-        interval.tick().await;
+
+    #[test]
+    fn retain_by_size() {
+        let dir = TempDir::new().unwrap();
+        let segments = vec![
+            create_test_segment(dir.path(), 1, 1000, 3600),
+            create_test_segment(dir.path(), 2, 1000, 1800),
+            create_test_segment(dir.path(), 3, 1000, 900),
+        ];
+
+        let config = RetentionConfig {
+            max_bytes: Some(2000), // Keep only 2KB
+            max_age: None,
+            check_interval: Duration::from_secs(1),
+        };
+
+        let policy = RetentionEnforcer::new(dir.path().to_path_buf(), config);
+        let to_delete = policy.evaluate(&segments).unwrap();
+
+        // Should delete the oldest segment (id=1)
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0].get(), 1);
+    }
+
+    #[test]
+    fn retain_by_ttl() {
+        let dir = TempDir::new().unwrap();
+        let segments = vec![
+            create_test_segment(dir.path(), 1, 1000, 7200), // 2 hours old
+            create_test_segment(dir.path(), 2, 1000, 3600), // 1 hour old
+            create_test_segment(dir.path(), 3, 1000, 1800), // 30 minutes old
+        ];
+
+        let config = RetentionConfig {
+            max_bytes: None,
+            max_age: Some(Duration::from_secs(5400)), // 1.5 hours
+            check_interval: Duration::from_secs(1),
+        };
+
+        let policy = RetentionEnforcer::new(dir.path().to_path_buf(), config);
+        let to_delete = policy.evaluate(&segments).unwrap();
+
+        // SegmentId=1 should be the only output.
+        // It is over the 1.5 hour retention window.
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0].get(), 1);
+    }
+
+    #[tokio::test]
+    async fn retention_manager() {
+        let dir = TempDir::new().unwrap();
+        let namespace = Namespace::new("test");
+        let namespace_dir = dir.path().join("test");
+        std::fs::create_dir(&namespace_dir).unwrap();
+
+        let segments = vec![
+            create_test_segment(&namespace_dir, 1, 1000, 3600),
+            create_test_segment(&namespace_dir, 2, 1000, 1800),
+        ];
+
+        let config = RetentionConfig {
+            max_bytes: Some(1500),
+            max_age: None,
+            check_interval: Duration::from_secs(1),
+        };
+
+        let manager = RetentionManager::new();
+
+        manager.policies.write().await.insert(
+            namespace.clone(),
+            RetentionEnforcer::new(namespace_dir, config),
+        );
+
+        let to_delete = manager
+            .check_retention(&namespace, &segments)
+            .await
+            .unwrap();
+        assert_eq!(to_delete.len(), 1);
     }
 }

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -276,6 +276,8 @@ impl RetentionManager {
 
 #[cfg(test)]
 mod tests {
+    use crate::log::find_segment_ids;
+
     use super::*;
     use std::fs::File;
     use std::io::Write;
@@ -367,11 +369,15 @@ mod tests {
             namespace.clone(),
             namespace_dir.clone(),
             config.clone(),
-            || vec![],
+            move || find_segment_ids(namespace_dir.clone()),
         );
 
-        let to_delete = manager.check_retention(&namespace, &segments).unwrap();
-        assert_eq!(to_delete.expect("contains namespace").len(), 1);
+        let to_delete = manager
+            .check_retention(&namespace, &segments)
+            .unwrap()
+            .expect("contains namespace");
+        assert_eq!(to_delete.len(), 1);
+        assert_eq!(to_delete[0], segments[0]);
         assert_eq!(manager.remove_namespace(&namespace), Some(namespace));
 
         let not_exist = manager

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -31,7 +31,7 @@ impl Default for RetentionConfig {
 
 /// A [`RetentionEnforcer`] will enforce the disk pressure and time-to-live (TTL)
 /// policy over a namespace contained at the specified directory.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct RetentionEnforcer {
     config: RetentionConfig,
     directory: PathBuf,
@@ -46,6 +46,7 @@ impl RetentionEnforcer {
     /// Returns segments that should be deleted
     pub fn evaluate(&self, segments: &[SegmentId]) -> Result<Vec<SegmentId>, std::io::Error> {
         let mut segments_to_delete = Vec::new();
+        info!(directory = %self.directory.display(), "retention evaluation");
 
         // Apply disk pressure retention if configured
         if let Some(max_bytes) = self.config.max_bytes {
@@ -155,6 +156,7 @@ impl RetentionEnforcer {
     }
 }
 
+#[derive(Debug)]
 /// Manager for retention enforcement across multiple namespaces.
 pub struct RetentionManager {
     enforcers: Arc<RwLock<HashMap<Namespace, (RetentionEnforcer, JoinHandle<()>)>>>,
@@ -168,15 +170,15 @@ impl RetentionManager {
     }
 
     /// Start retention for a new [`Namespace`].
-    pub async fn add_namespace(
+    pub fn add_namespace(
         &mut self,
         namespace: Namespace,
         log_directory: PathBuf,
         config: RetentionConfig,
+        // TODO: SegmentProvider trait to capture this behaviour?
         segment_provider: impl Fn() -> Vec<SegmentId> + Send + Sync + 'static,
     ) {
-        let directory = log_directory.join(namespace.inner());
-        let policy = RetentionEnforcer::new(directory.clone(), config.clone());
+        let policy = RetentionEnforcer::new(log_directory.clone(), config.clone());
 
         let policy_internal = policy.clone();
         let namespace_internal = namespace.clone();
@@ -231,9 +233,13 @@ impl RetentionManager {
         }
     }
 
+    pub fn contains_namespace(&self, namespace: &Namespace) -> bool {
+        self.enforcers.read().contains_key(namespace)
+    }
+
     /// Force a retention check against a namespace and specified
     /// segments.
-    pub async fn check_retention(
+    pub(crate) fn check_retention(
         &self,
         namespace: &Namespace,
         segments: &[SegmentId],
@@ -317,8 +323,8 @@ mod tests {
         assert_eq!(to_delete[0].get(), 1);
     }
 
-    #[tokio::test]
-    async fn retention_manager() {
+    #[test]
+    fn retention_manager() {
         let dir = TempDir::new().unwrap();
         let namespace = Namespace::new("test");
         let namespace_dir = dir.path().join("test");
@@ -345,10 +351,7 @@ mod tests {
             ),
         );
 
-        let to_delete = manager
-            .check_retention(&namespace, &segments)
-            .await
-            .unwrap();
+        let to_delete = manager.check_retention(&namespace, &segments).unwrap();
         assert_eq!(to_delete.len(), 1);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -170,7 +170,7 @@ impl Namespace for Arc<BigPipeServer> {
             return Err(Status::already_exists(format!("{key} already exists")));
         }
 
-        inner.create_namespace(namespace);
+        inner.create_namespace(namespace, None);
 
         Ok(Response::new(CreateNamespaceResponse { key }))
     }


### PR DESCRIPTION
Helps https://github.com/jdockerty/bigpipe/issues/5

Adds retention wiring and implementation. The enforcement policies are not currently configurable and are ensured that they are applied across time or disk usage, specifically segment sizing.